### PR TITLE
make prefixes monospaced

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -52,6 +52,9 @@ body {
   font-size: 21px;
   padding: 14px 24px;
 }
+.prefix {
+  font-family: Monospace;
+}
 
 /* Supporting marketing content */
 .marketing {

--- a/css/styles.css
+++ b/css/styles.css
@@ -52,8 +52,25 @@ body {
   font-size: 21px;
   padding: 14px 24px;
 }
+
+.jumbotron .prefix {
+    font-size: 50px;
+}
+
 .prefix {
-  font-family: Monospace;
+    font-family: Monospace;
+    font-weight: bold;
+}
+
+.sub-1st, .sub-last {
+    font-family: Monospace;
+}
+
+.sub-1st {
+    color: #007700;
+}
+.sub-last {
+    color: #770000;
 }
 
 /* Supporting marketing content */

--- a/js/uniquelocal.js
+++ b/js/uniquelocal.js
@@ -15,8 +15,8 @@ function random_ipv6()
 {
     var prefix = Array(
     'fd' + random_block(8, true),
-    random_block(16, false),
-    random_block(16, false)).join(':');
+    random_block(16, true),
+    random_block(16, true)).join(':');
     return prefix;
 }
 


### PR DESCRIPTION
It bothered me that the prefix was variable-width, making it slide around on the page when regenerated.